### PR TITLE
Use port number when waiting for SSHD

### DIFF
--- a/lib/kitchen/driver/ssh.rb
+++ b/lib/kitchen/driver/ssh.rb
@@ -13,7 +13,7 @@ module Kitchen
          state[:hostname] = config[:hostname]
          state[:password] = config[:password]
          print "Kitchen-ssh does not start your server '#{state[:hostname]}' but will look for an ssh connection with user '#{state[:username]}'"
-         wait_for_sshd(state[:hostname], state[:username])
+         wait_for_sshd(state[:hostname], state[:username], {:port => state[:port]})
          print "Kitchen-ssh found ssh ready on host '#{state[:hostname]}' with user '#{state[:username]}'\n"
          debug("ssh:create '#{state[:hostname]}'")
        end


### PR DESCRIPTION
Allow non-standard port numbers to be used when waiting for the SSH daemon at the start
