### PR TITLE
Remove escape code from user output

### DIFF
--- a/lib/kitchen/driver/ssh.rb
+++ b/lib/kitchen/driver/ssh.rb
@@ -21,7 +21,7 @@ module Kitchen
        def destroy(state)
          print "Kitchen-ssh does not destroy your server '#{state[:hostname]}' by shutting it down..."
          print "Shutdown your server '#{state[:hostname]}' natively with user '#{state[:username]}'"
-         print 'in your cloud or virtualisation console etc.\n'
+         print 'in your cloud or virtualisation console etc.'
          debug("ssh:destroy '#{state[:hostname]}'")
        end
 

--- a/lib/kitchen/driver/ssh_gzip.rb
+++ b/lib/kitchen/driver/ssh_gzip.rb
@@ -21,7 +21,7 @@ module Kitchen
        def destroy(state)
          print "Kitchen-sshGzip does not destroy your server '#{state[:hostname]}' by shutting it down..."
          print "Shutdown your server '#{state[:hostname]}' natively with user '#{state[:username]}'"
-         print 'in your cloud or virtualisation console etc.\n'
+         print 'in your cloud or virtualisation console etc.'
          debug("ssh:destroy '#{state[:hostname]}'")
        end
 


### PR DESCRIPTION
Trivial fix. '\n' in single quoted string.

Output seems fine without empty line. Alternatively change to double quotes.