### PR TITLE
Fix of syntax error

### DIFF
--- a/lib/kitchen/driver/ssh.rb
+++ b/lib/kitchen/driver/ssh.rb
@@ -11,7 +11,7 @@ module Kitchen
          state[:forward_agent] = config[:forward_agent] if config[:forward_agent]
          state[:username] = config[:username]
          state[:hostname] = config[:hostname]
-         state[:password] = config[:password] if config[:password]?
+         state[:password] = config[:password] if config[:password]
          print "Kitchen-ssh does not start your server '#{state[:hostname]}' but will look for an ssh connection with user '#{state[:username]}'"
          wait_for_sshd(state[:hostname], state[:username], {:port => state[:port]})
          print "Kitchen-ssh found ssh ready on host '#{state[:hostname]}' with user '#{state[:username]}'\n"


### PR DESCRIPTION
Related to https://github.com/neillturner/kitchen-ssh/issues/9#issuecomment-410975256

```bash
$ kitchen list
Traceback (most recent call last):
        24: from /Users/artem/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `<main>'
...
         1: from /Users/artem/.rvm/gems/ruby-2.5.1/gems/test-kitchen-1.23.3/lib/kitchen/driver.rb:38:in `for_plugin'
/Users/artem/.rvm/gems/ruby-2.5.1/gems/test-kitchen-1.23.3/lib/kitchen/driver.rb:38:in `require': /Users/artem/.rvm/gems/ruby-2.5.1/gems/kitchen-ssh-1.0.2/lib/kitchen/driver/ssh.rb:15: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '(' (SyntaxError)
         print "Kitchen-ssh does not start yo...
```